### PR TITLE
changed to using Notify in buffer for fixing loop without wait. added benchmark buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,8 @@ cc = "1.0.72"
 tokio-test = "0.4.2"
 env_logger = "0.9.0"
 chrono = "0.4.19"
+criterion = { version = "0.3.5", features = ["stable"]}
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,31 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::async_executor::FuturesExecutor;
+
+use webrtc_util::Buffer;
+
+async fn buffer_write_then_read(times: u32) {
+    let buffer = Buffer::new(0, 0);
+    let mut packet: Vec<u8> = vec![0; 4];
+    for _ in 0..times {
+        buffer.write(&[0, 1]).await.unwrap();
+        buffer.read(&mut packet, None).await.unwrap();
+    }
+}
+
+fn benchmark_buffer(c: &mut Criterion) {
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    c.bench_function("Benchmark Buffer WriteThenRead 1", |b| {
+        b.to_async(FuturesExecutor).iter(|| buffer_write_then_read(1));
+    });
+
+    c.bench_function("Benchmark Buffer WriteThenRead 10", |b| {
+        b.to_async(FuturesExecutor).iter(|| buffer_write_then_read(10));
+    });
+
+    c.bench_function("Benchmark Buffer WriteThenRead 100", |b| {
+        b.to_async(FuturesExecutor).iter(|| buffer_write_then_read(100));
+    });
+}
+
+criterion_group!(benches, benchmark_buffer);
+criterion_main!(benches);

--- a/src/buffer/buffer_test.rs
+++ b/src/buffer/buffer_test.rs
@@ -3,6 +3,7 @@ use crate::error::Error;
 
 use tokio::time::{sleep, Duration};
 use tokio_test::assert_ok;
+use tokio::sync::mpsc;
 
 #[tokio::test]
 async fn test_buffer() {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -4,7 +4,7 @@ mod buffer_test;
 use crate::error::{Error, Result};
 
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Notify, Mutex};
 use tokio::time::{timeout, Duration};
 
 const MIN_SIZE: usize = 2048;
@@ -19,10 +19,8 @@ struct BufferInternal {
     head: usize,
     tail: usize,
 
-    notify_tx: Option<mpsc::Sender<()>>,
-    notify_rx: Option<mpsc::Receiver<()>>,
-    subs: bool,
     closed: bool,
+    subs: bool,
 
     count: usize,
     limit_count: usize,
@@ -99,28 +97,25 @@ impl BufferInternal {
 #[derive(Debug, Clone)]
 pub struct Buffer {
     buffer: Arc<Mutex<BufferInternal>>,
+    notify: Arc<Notify>
 }
 
 impl Buffer {
     pub fn new(limit_count: usize, limit_size: usize) -> Self {
-        let (notify_tx, notify_rx) = mpsc::channel(1);
-
         Buffer {
             buffer: Arc::new(Mutex::new(BufferInternal {
                 data: vec![],
                 head: 0,
                 tail: 0,
 
-                notify_tx: Some(notify_tx),
-                notify_rx: Some(notify_rx),
-
-                subs: false,
                 closed: false,
+                subs: false,
 
                 count: 0,
                 limit_count,
                 limit_size,
             })),
+            notify: Arc::new(Notify::new())
         }
     }
 
@@ -149,24 +144,6 @@ impl Buffer {
         while !b.available(packet.len()) {
             b.grow()?;
         }
-
-        let mut notify = if b.subs {
-            // readers are waiting.  Prepare to notify, but only
-            // actually do it after we release the lock.
-            let notify = b.notify_tx.take();
-
-            let (notify_tx, notify_rx) = mpsc::channel(1);
-
-            b.notify_tx = Some(notify_tx);
-            b.notify_rx = Some(notify_rx);
-
-            // Reset the subs marker.
-            b.subs = false;
-
-            notify
-        } else {
-            None
-        };
 
         // store the length of the packet
         let tail = b.tail;
@@ -197,9 +174,10 @@ impl Buffer {
         }
         b.count += 1;
 
-        // Actually close the notify channel down here.
-        if notify.is_some() {
-            notify.take(); //drop notify
+        if b.subs {
+            // we have other are waiting data
+            self.notify.notify_one();
+            b.subs = false;
         }
 
         Ok(packet.len())
@@ -211,7 +189,6 @@ impl Buffer {
     // Returns io.EOF if the buffer is closed.
     pub async fn read(&self, packet: &mut [u8], duration: Option<Duration>) -> Result<usize> {
         loop {
-            let notify;
             {
                 // use {} to let LockGuard RAII
                 let mut b = self.buffer.lock().await;
@@ -264,27 +241,23 @@ impl Buffer {
                         return Err(Error::ErrBufferShort);
                     }
                     return Ok(copied);
+                } else {
+                    // Dont have data -> need wait
+                    b.subs = true;
                 }
 
                 if b.closed {
                     return Err(Error::ErrBufferClosed);
                 }
-
-                notify = b.notify_rx.take();
-
-                // Set the subs marker, telling the writer we're waiting.
-                b.subs = true
             }
 
-            // Wake for the broadcast.
-            if let Some(mut notify) = notify {
-                if let Some(d) = duration {
-                    if timeout(d, notify.recv()).await.is_err() {
-                        return Err(Error::ErrTimeout);
-                    }
-                } else {
-                    notify.recv().await;
+            // Wait for signal.
+            if let Some(d) = duration {
+                if timeout(d, self.notify.notified()).await.is_err() {
+                    return Err(Error::ErrTimeout);
                 }
+            } else {
+                self.notify.notified().await;
             }
         }
     }
@@ -300,8 +273,8 @@ impl Buffer {
             return;
         }
 
-        b.notify_tx.take();
         b.closed = true;
+        self.notify.notify_waiters();
     }
 
     pub async fn is_closed(&self) -> bool {


### PR DESCRIPTION
Benchmark results: performance increased 

```
Benchmark Buffer WriteThenRead 1                                                                            
                        time:   [188.79 ns 189.19 ns 189.59 ns]
                        change: [-0.8572% -0.5335% -0.2205%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

Benchmark Buffer WriteThenRead 10                                                                             
                        time:   [688.36 ns 689.49 ns 690.68 ns]
                        change: [-4.3763% -4.1819% -3.9965%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

Benchmark Buffer WriteThenRead 100                                                                             
                        time:   [5.6106 us 5.6141 us 5.6187 us]
                        change: [-4.8644% -4.7267% -4.5841%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  9 (9.00%) high mild
  5 (5.00%) high severe
```